### PR TITLE
Header refactor

### DIFF
--- a/group/blocks/columns/columns.css
+++ b/group/blocks/columns/columns.css
@@ -1,3 +1,7 @@
+.columns:not(.striped-rows) {
+  padding: var(--spacing-xl) 0;
+}
+
 .columns > div {
   display: flex;
   flex-direction: column;
@@ -60,6 +64,14 @@
   z-index: -1;
   transform: translateX(-50%);
   left: 50%;
+}
+
+.columns.striped-rows p.button-container a {
+  margin: 0;
+} 
+
+.columns.striped-rows p:not(.button-container) a {
+  padding-left: 1.2rem;
 }
 
 .columns.shaded > div {

--- a/group/blocks/columns/columns.css
+++ b/group/blocks/columns/columns.css
@@ -1,6 +1,7 @@
 .columns > div {
   display: flex;
   flex-direction: column;
+  margin: 0 var(--spacing-xl);
 }
 
 .columns img {
@@ -72,7 +73,7 @@
 }
 
 
-@media (width >= 768px) {
+@media (width >= 900px) {
   .columns > div {
     align-items: center;
     flex-direction: unset;

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -1,7 +1,3 @@
-main .section > .fragment-wrapper {
-  margin: auto;
-}
-
 .fragment-wrapper:has(.full-width) {
   padding: 0;
   margin: 0;
@@ -9,6 +5,10 @@ main .section > .fragment-wrapper {
 
 .fragment-wrapper:has(.full-width) .full-width {
   width: 100dvw;
+}
+
+main .section > .fragment-wrapper {
+  margin: auto;
 }
 
 .fragment-wrapper div:not(.full-width) {

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -64,7 +64,6 @@
 }
 
 @media (width >= 600px) {
-
   .fragment-wrapper .two-col {
     display: flex;
     flex-direction: row-reverse;

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -1,3 +1,7 @@
+main .section > .fragment-wrapper {
+  margin: auto;
+}
+
 .fragment-wrapper:has(.full-width) {
   padding: 0;
   margin: 0;

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -8,7 +8,7 @@
 }
 
 main .section > .fragment-wrapper {
-  margin: auto;
+  margin: 0 var(--spacing-m);
 }
 
 .fragment-wrapper div:not(.full-width) {
@@ -68,6 +68,10 @@ main .section > .fragment-wrapper {
 }
 
 @media (width >= 600px) {
+  main .section > .fragment-wrapper {
+    margin: auto;
+  }
+
   .fragment-wrapper .two-col {
     display: flex;
     flex-direction: row-reverse;

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -3,6 +3,10 @@
   margin: 0;
 }
 
+.fragment-container.full-width .fragment-wrapper {
+  max-width: fit-content;
+}
+
 .fragment-wrapper:has(.full-width) .full-width {
   width: 100dvw;
 }
@@ -10,6 +14,10 @@
 .fragment-wrapper div:not(.full-width) {
   max-width: 1200px;
   margin: 0 auto;
+}
+
+.fragment-wrapper div.section:not(.full-width) {
+  margin: 0 var(--spacing-m);
 }
 
 .fragment-wrapper .shaded {
@@ -54,6 +62,10 @@
   padding: 0 10%;
 }
 
+.fragment-wrapper .indent .default-content-wrapper {
+  padding-left: var(--spacing-m);
+}
+
 .fragment-wrapper .indent p {
   font-size: var(--body-font-size-m);
   margin-bottom: var(--spacing-m);
@@ -81,6 +93,14 @@
 
   .fragment-wrapper > .two-col > div:nth-child(2) {
     width: 33.333%;
+  }
+
+  .fragment-wrapper div.section:not(.full-width) {
+    margin: 0 auto;
+  }
+
+  .fragment-wrapper .indent .default-content-wrapper {
+    padding-left: var(--spacing-xxl);
   }
 }
 

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -7,10 +7,6 @@
   width: 100dvw;
 }
 
-main .section > .fragment-wrapper {
-  margin: 0 var(--spacing-m);
-}
-
 .fragment-wrapper div:not(.full-width) {
   max-width: 1200px;
   margin: 0 auto;
@@ -68,9 +64,6 @@ main .section > .fragment-wrapper {
 }
 
 @media (width >= 600px) {
-  main .section > .fragment-wrapper {
-    margin: auto;
-  }
 
   .fragment-wrapper .two-col {
     display: flex;

--- a/group/blocks/header/header.css
+++ b/group/blocks/header/header.css
@@ -12,10 +12,8 @@ header nav {
   box-sizing: border-box;
   display: grid;
   grid-template:
-    'brand hamburger' var(--nav-height)
-    'sections sections' 1fr / 1fr;
+    'brand hamburger' var(--nav-height) / 70% 30% 0;
   align-items: center;
-  gap: 0 24px;
   max-width: 1248px;
   height: var(--nav-height);
   padding: 0 24px 0 0;
@@ -26,7 +24,7 @@ header nav {
 header nav[aria-expanded='true'] {
   grid-template:
     'brand hamburger' var(--nav-height)
-    'sections sections' 1fr;
+    'sections sections' 1fr / 70% 30%;
   overflow-y: auto;
   min-height: 100dvh;
 }
@@ -62,6 +60,7 @@ header nav .nav-hamburger {
   height: 22px;
   display: flex;
   align-items: center;
+  justify-content: end;
 }
 
 header nav .nav-hamburger button {
@@ -91,10 +90,6 @@ header nav .nav-hamburger-icon::after {
   content: '';
   position: absolute;
   background: currentcolor;
-}
-
-header nav[aria-expanded='true'] .nav-hamburger{
-  justify-content: center;
 }
 
 header nav[aria-expanded='false'] .nav-hamburger-icon,

--- a/group/blocks/header/header.css
+++ b/group/blocks/header/header.css
@@ -35,7 +35,7 @@ header nav[aria-expanded='true'] {
     justify-content: space-between;
     gap: 0 32px;
     max-width: unset;
-    padding: 0 32px 0 0;
+    padding: 0;
   }
 
   header nav[aria-expanded='true'] {
@@ -218,10 +218,6 @@ header nav[aria-expanded='true'] .nav-sections ul > li > ul > li {
     width: 219px;
   }
 
-  header nav .nav-brand .icon img {
-    padding-left: 124px;
-  }
-
   header nav .nav-sections {
     display: block;
     visibility: visible;
@@ -234,7 +230,7 @@ header nav[aria-expanded='true'] .nav-sections ul > li > ul > li {
     width: unset;
     background-color: unset;
     color:unset;
-    padding: unset;
+    padding: 0 0 0 var(--spacing-xxl);
   }
 
   header nav[aria-expanded='true'] .nav-sections ul > li {
@@ -252,8 +248,8 @@ header nav[aria-expanded='true'] .nav-sections ul > li > ul > li {
     content: '';
     display: inline-block;
     position: absolute;
-    top: 1.7rem;
-    right: var(--spacing-m);
+    top: 1.5rem;
+    right: var(--spacing-s);
     transform: rotate(135deg);
     width: 6px;
     height: 6px;

--- a/group/blocks/header/header.css
+++ b/group/blocks/header/header.css
@@ -1,5 +1,11 @@
 /* header and nav layout */
 
+.header {
+  position: fixed;
+  width: 100%;
+  z-index: 100;
+}
+
 header .nav-wrapper {
   background-color: var(--background-color);
   width: 100%;

--- a/group/blocks/header/header.css
+++ b/group/blocks/header/header.css
@@ -95,7 +95,6 @@ header nav .nav-hamburger-icon::after {
 
 header nav[aria-expanded='true'] .nav-hamburger{
   justify-content: center;
-  padding-right: var(--spacing-l);
 }
 
 header nav[aria-expanded='false'] .nav-hamburger-icon,
@@ -160,7 +159,6 @@ header nav .nav-brand picture img {
 header nav .nav-brand .icon img {
   width: 128px;
   height: auto;
-  padding-left: 100px;
 }
 
 header nav .nav-brand .icon.icon-multi-state-logo img {

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -130,7 +130,7 @@ h6 {
   scroll-margin: 40px;
 }
 
-h1 { font-size: var(--heading-font-size-m); }
+h1 { font-size: var(--heading-font-size-xxl); }
 h2 { font-size: var(--heading-font-size-xl); }
 h3 { font-size: var(--heading-font-size-l); }
 h4 { font-size: var(--heading-font-size-m); }


### PR DESCRIPTION
Fix for #31 

Test URLs:
- Before: https://main--bsca-secondsale--aemsites.aem.live/group/traderjoes/tj1/muscle-joint-pain
- After: https://header-refactor--bsca-secondsale--aemsites.aem.page/group/traderjoes/tj1/muscle-joint-pain

Column changes
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/traderjoes/tj1
- After: https://header-refactor--bsca-secondsale--aemsites.aem.page/group/traderjoes/tj1

Contains following fixes:
1. Nav brand adjusted to the left
2. The hamburger icons position is adjusted.
3. Margin for fragment 
4. Corrected the breakpoint for column block.