### PR TITLE
two-col-fragment styling and importer updates

### DIFF
--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -123,5 +123,6 @@
 
   .fragment-container.two-col > .fragment-wrapper > div {
     flex: 1;
+    max-width: 50%;
   }
 }

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -114,4 +114,14 @@
   .fragment-wrapper > .three-col:nth-child(2) {
     width: 20%;
   }
+
+  .fragment-container.two-col > .fragment-wrapper {
+    display: flex;
+    gap: var(--spacing-xxl);
+
+  }
+
+  .fragment-container.two-col > .fragment-wrapper > div {
+    flex: 1;
+  }
 }

--- a/group/blocks/list/list.css
+++ b/group/blocks/list/list.css
@@ -2,15 +2,24 @@
     text-align: center;
 }
 
+.list-container.center-title h1,
+.list-container.center-title h2,
+.list-container.center-title h3,
+.list-container.center-title h4,
+.list-container.center-title h5,
+.list-container.center-title h6 {
+    text-align: center;
+}
+
 .list.border {
     background-color: var(--shade-color);
     border-radius: var(--border-radius-l);
     border: 1px solid var(--secondary-color);
-    margin-bottom: var(--spacing-xxl);
+    margin: var(--spacing-xxl);
 }
 
 .list.border > div > div {
-    padding: 0 var(--spacing-l);
+    padding: var(--spacing-s) var(--spacing-l);
 }
 
 .list.border ul {

--- a/tools/importer/importer-main.js
+++ b/tools/importer/importer-main.js
@@ -248,9 +248,14 @@ function importPlanOptions(main, document) {
     // Check for the second condition: 1 child that is col-lg-12 and does NOT contain a <sup>
     const colsMatch2 = children.length === 1
       && children[0].classList.contains('col-lg-12')
-      && !children[0].querySelector('sup');
+      && !children[0].querySelector('sup') && !children[0].querySelector('.kgo-collapsible');
 
-    return colsMatch || colsMatch2;
+    const colsMatch3 = children.length === 3
+      && children[0].classList.contains('col-lg-4')
+      && children[1].classList.contains('col-lg-6')
+      && children[2].classList.contains('col-lg-2');
+
+    return colsMatch || colsMatch2 || colsMatch3;
   });
 
   let sectionParent;


### PR DESCRIPTION
Fixing spacing issues in list and two column layout for index pages.

Test URLs:

2 col fragment
- Before: https://main--bsca-secondsale--aemsites.aem.live/group/oc/
- After: https://two-col-fragment--bsca-secondsale--aemsites.aem.page/group/oc/

List spacing
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/oc/dental/documents
- After: https://two-col-fragment--bsca-secondsale--aemsites.aem.page/group/oc/dental/documents