### PR TITLE
Fragment cards layout updates

### DIFF
--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -176,6 +176,11 @@
   .cards.secondary > ul > li > .cards-card-body p:nth-child(3) {
     font-size: var(--body-font-size-m);
   }
+  
+  .three-cards .cards ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 
   .two-cards .cards ul {
     flex-wrap: wrap;
@@ -184,11 +189,6 @@
 
   .two-cards .cards.list > ul {
     justify-content: flex-start;
-  }
-
-  .three-cards .cards ul {
-    flex-wrap: wrap;
-    justify-content: center;
   }
 
   .three-cards .cards > ul > li {

--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -181,4 +181,18 @@
     flex-wrap: wrap;
     justify-content: center;
   }
+
+  .two-cards .cards.list > ul {
+    justify-content: flex-start;
+  }
+
+  .three-cards .cards ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .three-cards .cards > ul > li {
+    max-width: 300px;
+    margin: var(--spacing-xl);
+  }
 }

--- a/group/blocks/columns/columns.css
+++ b/group/blocks/columns/columns.css
@@ -7,7 +7,7 @@
 }
 
 .columns.shaded-rows {
-  padding: 0;
+  padding: var(--spacing-m) 0;
 }
 
 .columns > div {
@@ -177,6 +177,11 @@
 .columns .icon-container .icon-title {
   padding: 0 var(--spacing-s);
   flex: 4;
+}
+
+.columns .icon-container .icon-title p,
+.columns .icon-container .icon-title h4 {
+  margin: 0;
 }
 
 @media (width >= 600px) {

--- a/group/blocks/columns/columns.css
+++ b/group/blocks/columns/columns.css
@@ -53,6 +53,11 @@
   font-size: var(--body-font-size-s);
 }
 
+.columns .icon-container .icon-title p,
+.columns .icon-container .icon-title h4 {
+  margin: 0;
+}
+
 .columns.columns-2-cols > div p:first-of-type {
   font-size: var(--body-font-size-m);
 }
@@ -177,11 +182,6 @@
 .columns .icon-container .icon-title {
   padding: 0 var(--spacing-s);
   flex: 4;
-}
-
-.columns .icon-container .icon-title p,
-.columns .icon-container .icon-title h4 {
-  margin: 0;
 }
 
 @media (width >= 600px) {

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -64,6 +64,10 @@
   margin: 0 auto;
 }
 
+.fragment-wrapper .centered-image p:has( > picture) {
+  text-align: center;
+}
+
 .fragment-wrapper .indent {
   padding: 0 10%;
 }
@@ -86,6 +90,15 @@
     display: flex;
     flex-direction: row;
     gap: var(--spacing-m);
+  }
+
+  .fragment-container.three-col.spacing-l > .fragment-wrapper {
+    margin-top: var(--spacing-xxl);
+    gap: var(--spacing-xxl);
+  }
+
+  .fragment-container.three-col.spacing-l > .fragment-wrapper > div {
+    max-width: 300px;
   }
 
   .fragment-container.two-col > .fragment-wrapper {

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -64,10 +64,6 @@
   margin: 0 auto;
 }
 
-.fragment-wrapper .centered-image p:has( > picture) {
-  text-align: center;
-}
-
 .fragment-wrapper .indent {
   padding: 0 10%;
 }
@@ -85,21 +81,16 @@
   font-size: var(--body-font-size-l);
 }
 
+.fragment-wrapper .centered-image p:has( > picture) {
+  text-align: center;
+}
+
 @media (width >= 900px) {
   .fragment-container.three-col > .fragment-wrapper {
     display: flex;
     flex-direction: row;
     gap: var(--spacing-m);
-  }
-
-  .fragment-container.three-col.spacing-l > .fragment-wrapper {
-    margin-top: var(--spacing-xxl);
-    gap: var(--spacing-xxl);
-  }
-
-  .fragment-container.three-col.spacing-l > .fragment-wrapper > div {
-    max-width: 300px;
-  }
+  } 
 
   .fragment-container.two-col > .fragment-wrapper {
     display: flex;
@@ -124,6 +115,15 @@
     padding-left: var(--spacing-m);
     padding-right: var(--spacing-m);
     padding-bottom: var(--spacing-l);
+  }
+
+  .fragment-container.three-col.spacing-l > .fragment-wrapper {
+    margin-top: var(--spacing-xxl);
+    gap: var(--spacing-xxl);
+  }
+
+  .fragment-container.three-col.spacing-l > .fragment-wrapper > div {
+    max-width: 300px;
   }
 
   .fragment-container.two-col.width-70-30 > .fragment-wrapper > div:first-child {

--- a/group/blocks/tabs/tabs.css
+++ b/group/blocks/tabs/tabs.css
@@ -85,11 +85,6 @@
   border-bottom: 1px solid var(--secondary-color);
 }
 
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-}
-
 .tabs .tabs-panel ul li:hover a {
   color: var(--link-color);
 }

--- a/group/blocks/tabs/tabs.css
+++ b/group/blocks/tabs/tabs.css
@@ -85,7 +85,6 @@
   border-bottom: 1px solid var(--secondary-color);
 }
 
-.tabs .tabs-panel ul li a {
   display: flex;
   justify-content: space-between;
   width: 100%;

--- a/group/styles/lazy-styles.css
+++ b/group/styles/lazy-styles.css
@@ -1,1 +1,4 @@
 /* add global styles that can be loaded post LCP here */
+main .centered-image p:has( > picture) {
+  text-align: center;
+}


### PR DESCRIPTION
1. Fragment layout to support plan options in federal site
2. Cards layout updates to support virtual events page in federal site

Test URLs:
Fragment layout updates
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/drafts/federal/
- After: https://fragment-cards-layout-updates--bsca-secondsale--aemsites.aem.page/group/drafts/federal/

Cards layout
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/drafts/federal/virtual-events
- After: https://fragment-cards-layout-updates--bsca-secondsale--aemsites.aem.page/group/drafts/federal/virtual-events