### PR TITLE
Mdc 525876 card header alignment

### DIFF
--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -38,7 +38,7 @@
   font-size: var(--body-font-size-l);
 }
 
-.cards.list .cards-card-body p:not(.button-container) {
+.cards.list .cards-card-body p:not(.button-container):not(:has( > strong)) {
   margin: 0 0 var(--spacing-xxl);
 }
 

--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -38,7 +38,7 @@
   font-size: var(--body-font-size-l);
 }
 
-.cards.list .cards-card-body p:not(.button-container):not(:has( > strong)) {
+.cards.list .cards-card-body p:not(.button-container,:has( > strong)) {
   margin: 0 0 var(--spacing-xxl);
 }
 

--- a/group/blocks/chatbot/chatbot.css
+++ b/group/blocks/chatbot/chatbot.css
@@ -8,7 +8,7 @@
     margin-top: var(--spacing-xxl);  
 }
 
-.chatbot > div > .col-right > p:not(:first-child) {
+.chatbot > div > .col-right > p:has( + ul):not(:first-child) {
     border-top: 1px solid var(--dark-color);
     padding-top: var(--spacing-l);
 }

--- a/group/blocks/chatbot/chatbot.js
+++ b/group/blocks/chatbot/chatbot.js
@@ -63,7 +63,15 @@ export default function decorate(block) {
   }
 
   // Split <p> tags based on two or more <br> tags
-  const paragraphs = block.querySelectorAll('p');
+  let paragraphs = block.querySelectorAll('p');
+  paragraphs.forEach((p) => {
+    if (p.nextElementSibling && p.nextElementSibling.tagName === 'P') {
+      p.innerHTML += `<br>${p.nextElementSibling.innerHTML}`;
+      p.nextElementSibling.remove();
+    }
+  });
+  paragraphs = block.querySelectorAll('p');
+
   paragraphs.forEach((p) => {
     if (p.innerHTML.includes('<br>')) {
       // Use a regular expression to split on two or more <br> tags

--- a/group/blocks/columns/columns.css
+++ b/group/blocks/columns/columns.css
@@ -233,6 +233,10 @@
     padding: var(--spacing-m) var(--spacing-s) var(--spacing-l);
   }
 
+  .columns.striped-rows.align-top > div {
+    align-items: flex-start;
+  }
+
   .columns.striped-rows > div:has(> div:only-child) {
     padding: 0 var(--spacing-s);
   }

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -411,3 +411,8 @@ a .icon-new-tab {
   white-space: nowrap;
   border: 0;
 }
+
+main > .section.border-top > .default-content-wrapper {
+  border-top: 1px solid var(--dark-color);
+  padding-top: var(--spacing-xl);
+}


### PR DESCRIPTION
Fix for two col card title spacing (Programs and services section
Adding a border-top for disclaimer section for cape

Test URLs:
two-col card
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/advantagesolutions/
- After: https://mdc-525876-card-header-alignment--bsca-secondsale--aemsites.aem.page/group/advantagesolutions/

border-top (disclaimer)
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/cape/dental
- After: https://mdc-525876-card-header-alignment--bsca-secondsale--aemsites.aem.page/group/cape/dental

chatbot border 
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/stanford
- After: https://mdc-525876-card-header-alignment--bsca-secondsale--aemsites.aem.page/group/stanford/

align-top fix
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/cseba/pharmacy
- After: https://mdc-525876-card-header-alignment--bsca-secondsale--aemsites.aem.page/group/cseba/pharmacy
