### PR TITLE
Side by side buttons on CCPOA page

### DIFF
--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -163,3 +163,21 @@
     padding-left: var(--spacing-xxl);
   }
 }
+
+/* Only the two buttons under the "CCPOA Active plan" section */
+#ccpoa-active-plan ~ .button-container {
+  display: inline-block;
+  vertical-align: top;
+  width: calc(50% - 8px);
+  margin-right: 16px;
+}
+#ccpoa-active-plan ~ .button-container:last-of-type { margin-right: 0; }
+
+/* Mobile: stack */
+@media (max-width: 640px) {
+  #ccpoa-active-plan ~ .button-container {
+    display: block;
+    width: 100%;
+    margin-right: 0;
+  }
+}

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -168,8 +168,7 @@
 #ccpoa-active-plan ~ .button-container {
   display: inline-block;
   vertical-align: top;
-  width: calc(50% - 8px);
-  margin-right: 16px;
+  margin-right: 32px;
 }
 #ccpoa-active-plan ~ .button-container:last-of-type { margin-right: 0; }
 

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -174,7 +174,7 @@
 #ccpoa-active-plan ~ .button-container:last-of-type { margin-right: 0; }
 
 /* Mobile: stack */
-@media (max-width: 640px) {
+@media (width <= 640px) {
   #ccpoa-active-plan ~ .button-container {
     display: block;
     width: 100%;


### PR DESCRIPTION
- Layout: render the two CCPOA “Active plan” buttons side-by-side with a fixed 40px gap.
- Keeps mobile stacking (≤640px) via range-syntax media query.
- Scoped to the fragment; no impact outside the CCPOA section.

Changed: group/blocks/fragment/fragment.css

Test URLs:
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/ccpoa/
- After: https://side-by-side--bsca-secondsale--aemsites.aem.page/group/drafts/matt-sorensen/ccpoa/
