### PR TITLE
Add video modal functionality (modal.js + modal.css)

### DIFF
--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -1,0 +1,95 @@
+// scripts/modal.js
+// Turns Vimeo/YouTube links into a modal player inside sections opted-in via Metadata:
+//   Style: use-video-modal
+// Works with plain links and linked images.
+// Fallback: if JS fails, the link still opens on Vimeo/YouTube.
+
+(() => {
+  const SECTION_SELECTOR = '.section.use-video-modal';
+  const LINK_SELECTOR =
+    `${SECTION_SELECTOR} a[href*="vimeo.com"], ${SECTION_SELECTOR} a[href*="youtube.com"], ${SECTION_SELECTOR} a[href*="youtu.be"]`;
+
+  function buildPlayerSrc(href) {
+    try {
+      const u = new URL(href);
+
+      // Vimeo
+      if (u.hostname.includes('vimeo.com')) {
+        // Accept /123456 or /video/123456
+        const parts = u.pathname.split('/').filter(Boolean);
+        const id = parts.pop();
+        if (!id || isNaN(Number(id))) return href;
+        return `https://player.vimeo.com/video/${id}?autoplay=1&muted=1&playsinline=1`;
+      }
+
+      // YouTube
+      if (u.hostname.includes('youtube.com') || u.hostname.includes('youtu.be')) {
+        let vid = u.searchParams.get('v');
+        if (!vid && u.hostname.includes('youtu.be')) {
+          vid = u.pathname.replace('/', '');
+        }
+        if (!vid) return href;
+        return `https://www.youtube.com/embed/${vid}?autoplay=1&mute=1&rel=0&playsinline=1`;
+      }
+    } catch (e) { /* ignore bad URLs */ }
+    return href;
+  }
+
+  function ensureRoot() {
+    let root = document.querySelector('.video-modal-root');
+    if (!root) {
+      root = document.createElement('div');
+      root.className = 'video-modal-root';
+      document.body.append(root);
+    }
+    return root;
+  }
+
+  function openModal(src, trigger) {
+    const root = ensureRoot();
+    const overlay = document.createElement('div');
+    overlay.className = 'video-modal-overlay';
+    overlay.innerHTML = `
+      <div class="video-modal-dialog" role="dialog" aria-modal="true" aria-label="Video player">
+        <button class="video-modal-close" type="button" aria-label="Close">×</button>
+        <div class="video-modal-frame">
+          <iframe src="${src}" title="Video" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen loading="eager"></iframe>
+        </div>
+      </div>
+    `;
+    root.append(overlay);
+
+    // Scroll lock + focus
+    const prevOverflow = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = 'hidden';
+    const closeBtn = overlay.querySelector('.video-modal-close');
+    closeBtn.focus();
+
+    function close() {
+      overlay.remove();
+      document.documentElement.style.overflow = prevOverflow;
+      if (trigger) trigger.focus();
+      document.removeEventListener('keydown', onKey);
+    }
+    function onKey(e) { if (e.key === 'Escape') close(); }
+
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+    closeBtn.addEventListener('click', close);
+    document.addEventListener('keydown', onKey);
+  }
+
+  // Event delegation: activate only inside opted-in sections
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest('a');
+    if (!a || !a.matches(LINK_SELECTOR)) return;
+
+    // Only intercept left-click without modifier keys
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+    const src = buildPlayerSrc(a.href);
+    if (!src) return; // fallback to normal nav
+
+    e.preventDefault();
+    openModal(src, a);
+  });
+})();

--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -75,16 +75,16 @@
     const closeBtn = overlay.querySelector('.video-modal-close');
     closeBtn.focus();
 
-    // define onKey BEFORE any use (so eslint is happy)
-    const onKey = (e) => {
-      if (e.key === 'Escape') close();
-    };
-
+    // define close FIRST so eslint is happy
     const close = () => {
       overlay.remove();
       document.documentElement.style.overflow = prevOverflow;
       if (trigger) trigger.focus();
       document.removeEventListener('keydown', onKey);
+    };
+
+    const onKey = (e) => {
+      if (e.key === 'Escape') close();
     };
 
     overlay.addEventListener('click', (e) => {
@@ -99,7 +99,7 @@
     const a = e.target.closest('a');
     if (!a || !a.matches(LINK_SELECTOR)) return;
 
-    // Only intercept plain left-clicks (operators at line start per lint rule)
+    // Only intercept plain left-clicks
     if (
       e.defaultPrevented || e.button !== 0
       || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey

--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -75,16 +75,16 @@
     const closeBtn = overlay.querySelector('.video-modal-close');
     closeBtn.focus();
 
-    // define close FIRST so eslint is happy
+    // define onKey first
+    const onKey = (e) => {
+      if (e.key === 'Escape') close();
+    };
+
     const close = () => {
       overlay.remove();
       document.documentElement.style.overflow = prevOverflow;
       if (trigger) trigger.focus();
       document.removeEventListener('keydown', onKey);
-    };
-
-    const onKey = (e) => {
-      if (e.key === 'Escape') close();
     };
 
     overlay.addEventListener('click', (e) => {

--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -75,15 +75,16 @@
     const closeBtn = overlay.querySelector('.video-modal-close');
     closeBtn.focus();
 
+    // define onKey BEFORE any use (so eslint is happy)
+    const onKey = (e) => {
+      if (e.key === 'Escape') close();
+    };
+
     const close = () => {
       overlay.remove();
       document.documentElement.style.overflow = prevOverflow;
       if (trigger) trigger.focus();
       document.removeEventListener('keydown', onKey);
-    };
-
-    const onKey = (e) => {
-      if (e.key === 'Escape') close();
     };
 
     overlay.addEventListener('click', (e) => {
@@ -98,11 +99,13 @@
     const a = e.target.closest('a');
     if (!a || !a.matches(LINK_SELECTOR)) return;
 
-    // Only intercept plain left-clicks
+    // Only intercept plain left-clicks (operators at line start per lint rule)
     if (
       e.defaultPrevented || e.button !== 0
       || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey
-    ) return;
+    ) {
+      return;
+    }
 
     const src = buildPlayerSrc(a.href);
     if (!src) return;

--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -39,7 +39,9 @@
           '?autoplay=1&mute=1&rel=0&playsinline=1',
         ].join('');
       }
-    } catch (e) { /* ignore bad URLs */ }
+    } catch (e) {
+      /* ignore bad URLs */
+    }
     return href;
   }
 
@@ -75,7 +77,9 @@
     const closeBtn = overlay.querySelector('.video-modal-close');
     closeBtn.focus();
 
-    // --- define functions as declarations (hoisted) ---
+    // Declare the handler first so it's not "used before defined"
+    let onKey;
+
     function close() {
       overlay.remove();
       document.documentElement.style.overflow = prevOverflow;
@@ -83,10 +87,9 @@
       document.removeEventListener('keydown', onKey);
     }
 
-    function onKey(e) {
+    onKey = (e) => {
       if (e.key === 'Escape') close();
-    }
-    // --------------------------------------------------
+    };
 
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();

--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -100,8 +100,8 @@
 
     // Only intercept plain left-clicks
     if (
-      e.defaultPrevented || e.button !== 0 ||
-      e.metaKey || e.ctrlKey || e.shiftKey || e.altKey
+      e.defaultPrevented || e.button !== 0
+      || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey
     ) return;
 
     const src = buildPlayerSrc(a.href);

--- a/group/scripts/modal.js
+++ b/group/scripts/modal.js
@@ -10,7 +10,7 @@
     `${SECTION_SELECTOR} a[href*="youtu.be"]`,
   ].join(', ');
 
-  const buildPlayerSrc = (href) => {
+  function buildPlayerSrc(href) {
     try {
       const u = new URL(href);
 
@@ -41,9 +41,9 @@
       }
     } catch (e) { /* ignore bad URLs */ }
     return href;
-  };
+  }
 
-  const ensureRoot = () => {
+  function ensureRoot() {
     let root = document.querySelector('.video-modal-root');
     if (!root) {
       root = document.createElement('div');
@@ -51,9 +51,9 @@
       document.body.append(root);
     }
     return root;
-  };
+  }
 
-  const openModal = (src, trigger) => {
+  function openModal(src, trigger) {
     const root = ensureRoot();
     const overlay = document.createElement('div');
     overlay.className = 'video-modal-overlay';
@@ -75,24 +75,25 @@
     const closeBtn = overlay.querySelector('.video-modal-close');
     closeBtn.focus();
 
-    // define onKey first
-    const onKey = (e) => {
-      if (e.key === 'Escape') close();
-    };
-
-    const close = () => {
+    // --- define functions as declarations (hoisted) ---
+    function close() {
       overlay.remove();
       document.documentElement.style.overflow = prevOverflow;
       if (trigger) trigger.focus();
       document.removeEventListener('keydown', onKey);
-    };
+    }
+
+    function onKey(e) {
+      if (e.key === 'Escape') close();
+    }
+    // --------------------------------------------------
 
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
     closeBtn.addEventListener('click', close);
     document.addEventListener('keydown', onKey);
-  };
+  }
 
   // Delegate clicks only inside opted-in sections
   document.addEventListener('click', (e) => {

--- a/group/scripts/scripts.js
+++ b/group/scripts/scripts.js
@@ -13,6 +13,8 @@ import {
   loadCSS,
 } from './aem.js';
 
+import './modal.js';
+
 /**
  * Returns the current timestamp used for scheduling content.
  */

--- a/group/styles/modal.css
+++ b/group/styles/modal.css
@@ -1,0 +1,35 @@
+/* styles/modal.css */
+/* Overlay */
+.video-modal-root .video-modal-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: rgba(0,0,0,.8);
+  display: flex; align-items: center; justify-content: center;
+  padding: 4vw;
+}
+
+/* Dialog */
+.video-modal-root .video-modal-dialog {
+  position: relative;
+  width: min(92vw, 960px);
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border-radius: 10px;
+  box-shadow: 0 20px 60px rgba(0,0,0,.5);
+  overflow: hidden;
+}
+
+/* Close button */
+.video-modal-root .video-modal-close {
+  position: absolute; top: 8px; right: 10px;
+  width: 36px; height: 36px;
+  border-radius: 999px;
+  border: 0; background: rgba(255,255,255,.9);
+  font-size: 24px; line-height: 1; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+}
+
+/* Frame */
+.video-modal-root .video-modal-frame { position: absolute; inset: 0; }
+.video-modal-root .video-modal-frame iframe {
+  position: absolute; inset: 0; width: 100%; height: 100%; border: 0;
+}

--- a/group/styles/modal.css
+++ b/group/styles/modal.css
@@ -1,35 +1,64 @@
-/* styles/modal.css */
-/* Overlay */
+/* group/styles/modal.css */
+
+/* Root overlay */
 .video-modal-root .video-modal-overlay {
-  position: fixed; inset: 0; z-index: 9999;
-  background: rgba(0,0,0,.8);
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgb(0 0 0 / 80%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 4vw;
 }
 
-/* Dialog */
+/* Dialog box */
 .video-modal-root .video-modal-dialog {
   position: relative;
   width: min(92vw, 960px);
   aspect-ratio: 16 / 9;
   background: #000;
   border-radius: 10px;
-  box-shadow: 0 20px 60px rgba(0,0,0,.5);
+  box-shadow: 0 20px 60px rgb(0 0 0 / 50%);
   overflow: hidden;
 }
 
 /* Close button */
 .video-modal-root .video-modal-close {
-  position: absolute; top: 8px; right: 10px;
-  width: 36px; height: 36px;
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  width: 36px;
+  height: 36px;
   border-radius: 999px;
-  border: 0; background: rgba(255,255,255,.9);
-  font-size: 24px; line-height: 1; cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
+  border: 0;
+  background: rgb(255 255 255 / 90%);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #000;
+  font-weight: bold;
+  transition: background 0.2s ease-in-out;
 }
 
-/* Frame */
-.video-modal-root .video-modal-frame { position: absolute; inset: 0; }
+.video-modal-root .video-modal-close:hover {
+  background: rgb(255 255 255 / 100%);
+}
+
+/* Frame wrapper */
+.video-modal-root .video-modal-frame {
+  position: absolute;
+  inset: 0;
+}
+
+/* Responsive iframe */
 .video-modal-root .video-modal-frame iframe {
-  position: absolute; inset: 0; width: 100%; height: 100%; border: 0;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
 }

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -10,6 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
+ @import './modal.css';
+
+
 :root {
   /* colors */
   --background-color: white;


### PR DESCRIPTION
This PR introduces a modal video player for Vimeo/YouTube links.

- Added modal.js to intercept video links and open in modal overlay
- Added modal.css for styling and responsiveness
- Updated scripts.js and styles.css to include modal imports
- Sections can opt-in with metadata: `style | use-video-modal`

Tested on draft and preview URLs. Videos open in modal as expected.

Test URLs:
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/newfront/
- After: https://modal--bsca-secondsale--aemsites.aem.page/group/drafts/matt-sorensen/newfront/index-3
