### PR TITLE
Normalize body text sizing on Newfront page (headings untouched)

### DIFF
--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -180,3 +180,10 @@
     margin-right: 0;
   }
 }
+
+/* Scope to Newfront page only */
+.section.newfront-page :where(p, li, span, a, td, th, figcaption, small) {
+  font-size: var(--body-font-size-m);
+  line-height: var(--body-line-height, 1.6); /* optional, for readability */
+}
+

--- a/group/blocks/fragment/fragment.css
+++ b/group/blocks/fragment/fragment.css
@@ -181,9 +181,3 @@
   }
 }
 
-/* Scope to Newfront page only */
-.section.newfront-page :where(p, li, span, a, td, th, figcaption, small) {
-  font-size: var(--body-font-size-m);
-  line-height: var(--body-line-height, 1.6); /* optional, for readability */
-}
-

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -419,3 +419,10 @@ main > .section.border-top > .default-content-wrapper {
   border-top: 1px solid var(--dark-color);
   padding-top: var(--spacing-xl);
 }
+
+/* Scope to Newfront page only */
+.section.newfront-page :where(p, li, span, a, td, th, figcaption, small) {
+  font-size: var(--body-font-size-m);
+  line-height: var(--body-line-height, 1.6); /* optional, for readability */
+}
+

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
- @import './modal.css';
+ @import url('./modal.css');
 
 
 :root {

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -420,9 +420,16 @@ main > .section.border-top > .default-content-wrapper {
   padding-top: var(--spacing-xl);
 }
 
-/* Scope to Newfront page only */
-.section.newfront-page :where(p, li, span, a, td, th, figcaption, small) {
+/* Newfront body copy override for Newfront page (headings untouched) */
+.section.newfront-page p,
+.section.newfront-page li,
+.section.newfront-page span,
+.section.newfront-page a,
+.section.newfront-page td,
+.section.newfront-page th,
+.section.newfront-page figcaption,
+.section.newfront-page small {
   font-size: var(--body-font-size-m);
-  line-height: var(--body-line-height, 1.6); /* optional, for readability */
+  line-height: var(--body-line-height, 1.6);
 }
 

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -426,5 +426,10 @@ main > .section.border-top > .default-content-wrapper {
   --body-font-size-s:  var(--body-font-size-m);
   --body-font-size-l:  var(--body-font-size-m);
   --body-font-size-xl: var(--body-font-size-m);
+
+  font-size: var(--body-font-size-m);
+  line-height: var(--body-line-height, 1.6);
 }
+
+
 

--- a/group/styles/styles.css
+++ b/group/styles/styles.css
@@ -420,16 +420,11 @@ main > .section.border-top > .default-content-wrapper {
   padding-top: var(--spacing-xl);
 }
 
-/* Newfront body copy override for Newfront page (headings untouched) */
-.section.newfront-page p,
-.section.newfront-page li,
-.section.newfront-page span,
-.section.newfront-page a,
-.section.newfront-page td,
-.section.newfront-page th,
-.section.newfront-page figcaption,
-.section.newfront-page small {
-  font-size: var(--body-font-size-m);
-  line-height: var(--body-line-height, 1.6);
+/* Make all body-copy sizes equal on Newfront page (headings untouched) */
+.section.newfront-page {
+  --body-font-size-xs: var(--body-font-size-m);
+  --body-font-size-s:  var(--body-font-size-m);
+  --body-font-size-l:  var(--body-font-size-m);
+  --body-font-size-xl: var(--body-font-size-m);
 }
 


### PR DESCRIPTION
This PR ensures that all body-copy elements (p, li, span, a, td, th, figcaption, small) render at the same font size (--body-font-size-m) on the Newfront page only. Headings (h1–h6) are not affected.

Added Section Metadata style: newfront-page in the document to scope changes.
In styles.css:

- Overrode body font-size variables (--body-font-size-xs, -s, -l, -xl) so they all resolve to --body-font-size-m within .section.newfront-page.
- Applied a section-level font-size: var(--body-font-size-m) so inherited elements (like ul, li, a) pick up the correct size.
- Added line-height: var(--body-line-height, 1.6) for consistent readability.
- Kept all code at the bottom of styles.css for easy visibility and minimal impact.

Test URLs:
- Before: https://main--bsca-secondsale--aemsites.aem.page/group/newfront/
- After: https://newfront-font--bsca-secondsale--aemsites.aem.page/group/drafts/matt-sorensen/newfront/
