### PR TITLE
Improve dropdown interactions: expand clickable area & consistent toggle

### DIFF
--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -207,6 +207,11 @@
     justify-content: center;
   }
 
+  /* variant for space-evenly layout */
+  .two-cards.space-evenly .cards ul {
+    justify-content: space-evenly;
+  }
+
   .two-cards .cards.list > ul {
     justify-content: flex-start;
   }

--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -207,12 +207,6 @@
     justify-content: center;
   }
 
-  /* variant for space-evenly layout */
-  .section.two-cards.space-evenly .cards > ul {
-  flex-wrap: wrap; 
-  justify-content: space-evenly;
-  }
-
   .two-cards .cards.list > ul {
     justify-content: flex-start;
   }
@@ -221,4 +215,11 @@
     max-width: 300px;
     margin: var(--spacing-xl);
   }
+
+  /* variant for space-evenly layout */
+  .section.two-cards.space-evenly .cards > ul {
+  flex-wrap: wrap; 
+  justify-content: space-evenly;
+  }
+
 }

--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -208,9 +208,9 @@
   }
 
   /* variant for space-evenly layout */
-  .two-cards.space-evenly .cards ul {
-    flex-wrap: wrap;
-    justify-content: space-evenly;
+  .section.two-cards.space-evenly .cards > ul {
+  flex-wrap: wrap; 
+  justify-content: space-evenly;
   }
 
   .two-cards .cards.list > ul {

--- a/group/blocks/cards/cards.css
+++ b/group/blocks/cards/cards.css
@@ -209,6 +209,7 @@
 
   /* variant for space-evenly layout */
   .two-cards.space-evenly .cards ul {
+    flex-wrap: wrap;
     justify-content: space-evenly;
   }
 

--- a/group/blocks/header/header.js
+++ b/group/blocks/header/header.js
@@ -3,12 +3,6 @@ import { loadFragment } from '../fragment/fragment.js';
 import { wrapTextInLinks } from '../../scripts/utils.js';
 import enableRowLinks from '../../scripts/row-link.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  enableRowLinks({
-    rows: 'header nav .nav-sections ul > li > ul > li',
-  });
-});
-
 // media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');
 
@@ -178,4 +172,10 @@ export default async function decorate(block) {
   navWrapper.className = 'nav-wrapper';
   navWrapper.append(nav);
   block.append(navWrapper);
+
+  // ⬇️ Make entire submenu <li> rows clickable (runs after header DOM is ready)
+  enableRowLinks({
+    root: block,
+    rows: '.nav-sections ul > li > ul > li',
+  });
 }

--- a/group/blocks/header/header.js
+++ b/group/blocks/header/header.js
@@ -1,6 +1,13 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 import { wrapTextInLinks } from '../../scripts/utils.js';
+import enableRowLinks from '../../scripts/row-link.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  enableRowLinks({
+    rows: 'header nav .nav-sections ul > li > ul > li',
+  });
+});
 
 // media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');

--- a/group/blocks/select/select.js
+++ b/group/blocks/select/select.js
@@ -1,4 +1,11 @@
 import { span } from '../../scripts/dom-helpers.js';
+import enableRowLinks from '../../scripts/row-link.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  enableRowLinks({
+    rows: '.select.block ul > li',
+  });
+});
 
 export default function decorate(block) {
   const selected = block.querySelector('p');

--- a/group/blocks/select/select.js
+++ b/group/blocks/select/select.js
@@ -21,7 +21,10 @@ export default function decorate(block) {
         .map((n) => n.textContent.trim())
         .join(' ');
 
+      // Replace only the text, then re-append the chevron
       selected.textContent = visibleText;
+      selected.append(icon);
+
       dropdown.classList.remove('open');
     });
   });

--- a/group/blocks/select/select.js
+++ b/group/blocks/select/select.js
@@ -1,12 +1,6 @@
 import { span } from '../../scripts/dom-helpers.js';
 import enableRowLinks from '../../scripts/row-link.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  enableRowLinks({
-    rows: '.select.block ul > li',
-  });
-});
-
 export default function decorate(block) {
   const selected = block.querySelector('p');
   const dropdown = block;
@@ -35,4 +29,8 @@ export default function decorate(block) {
   document.addEventListener('click', () => {
     dropdown.classList.remove('open');
   });
+
+  // Make the entire <li> clickable for this select block
+  // (runs after this block's DOM is ready)
+  enableRowLinks({ root: block, rows: 'ul > li' });
 }

--- a/group/scripts/row-link.js
+++ b/group/scripts/row-link.js
@@ -1,51 +1,37 @@
-// Make any <li> act like a link if it contains an <a>
-// No CSS required. Preserves accessibility & avoids conflicts.
-export default function enableRowLinks({ rows }) {
+// row-link.js
+export default function enableRowLinks({ rows, root = document }) {
   const interactors = 'a, button, input, select, textarea, [role="button"]';
 
-  document.querySelectorAll(rows).forEach((li) => {
-    // Find the first link in the row
+  root.querySelectorAll(rows).forEach((li) => {
     const link = li.querySelector('a[href]');
     if (!link) return;
 
-    // Mouse: click anywhere on the row → go to link
     li.addEventListener('click', (e) => {
-      // If the actual click was on an interactive element, let it behave normally
       if (e.target.closest(interactors)) return;
 
-      // Respect modifier keys / mouse buttons
       const href = link.getAttribute('href');
       const target = link.getAttribute('target') || '_self';
 
-      // Middle click or meta/ctrl → open in new tab
       if (e.button === 1 || e.metaKey || e.ctrlKey) {
         window.open(href, '_blank', 'noopener,noreferrer');
         return;
       }
-
-      // Shift-click usually means "new window"; emulate default browser behavior
       if (e.shiftKey) {
         window.open(href, target, 'noopener,noreferrer');
         return;
       }
-
-      // Otherwise navigate like a normal left-click
-      // Use link.click() to preserve analytics/click handlers attached to <a>
       link.click();
     });
 
-    // Keyboard: make the row focusable and activate on Enter/Space
     if (!li.hasAttribute('tabindex')) li.setAttribute('tabindex', '0');
     if (!li.hasAttribute('role')) li.setAttribute('role', 'link');
+    li.style.cursor = 'pointer';
 
     li.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault(); // prevent page scroll on Space
+        e.preventDefault();
         link.click();
       }
     });
-
-    // Optional: visual cue without CSS changes
-    li.style.cursor = 'pointer';
   });
 }

--- a/group/scripts/row-link.js
+++ b/group/scripts/row-link.js
@@ -1,0 +1,51 @@
+// Make any <li> act like a link if it contains an <a>
+// No CSS required. Preserves accessibility & avoids conflicts.
+export default function enableRowLinks({ rows }) {
+  const interactors = 'a, button, input, select, textarea, [role="button"]';
+
+  document.querySelectorAll(rows).forEach((li) => {
+    // Find the first link in the row
+    const link = li.querySelector('a[href]');
+    if (!link) return;
+
+    // Mouse: click anywhere on the row → go to link
+    li.addEventListener('click', (e) => {
+      // If the actual click was on an interactive element, let it behave normally
+      if (e.target.closest(interactors)) return;
+
+      // Respect modifier keys / mouse buttons
+      const href = link.getAttribute('href');
+      const target = link.getAttribute('target') || '_self';
+
+      // Middle click or meta/ctrl → open in new tab
+      if (e.button === 1 || e.metaKey || e.ctrlKey) {
+        window.open(href, '_blank', 'noopener,noreferrer');
+        return;
+      }
+
+      // Shift-click usually means "new window"; emulate default browser behavior
+      if (e.shiftKey) {
+        window.open(href, target, 'noopener,noreferrer');
+        return;
+      }
+
+      // Otherwise navigate like a normal left-click
+      // Use link.click() to preserve analytics/click handlers attached to <a>
+      link.click();
+    });
+
+    // Keyboard: make the row focusable and activate on Enter/Space
+    if (!li.hasAttribute('tabindex')) li.setAttribute('tabindex', '0');
+    if (!li.hasAttribute('role')) li.setAttribute('role', 'link');
+
+    li.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault(); // prevent page scroll on Space
+        link.click();
+      }
+    });
+
+    // Optional: visual cue without CSS changes
+    li.style.cursor = 'pointer';
+  });
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

This PR enhances the dropdown component for better usability and reliability:
Expands the clickable/tap area so the full label/container opens the dropdown.
Normalizes open/close toggle logic for consistent behavior.
Updates header.js (logic) and styles.css (minor selectors) related to dropdowns.
Lint-tested locally; no errors.
Verified across multiple pages; no regressions observed.

Test URLs

Before: [https://main--bsca-secondsale--aemsites.aem.page/group/ncsmig/](https://main--bsca-secondsale--aemsites.aem.page/group/ncsmig/)
After: [https://dropdownjs--bsca-secondsale--aemsites.aem.page/group/ncsmig/](https://dropdownjs--bsca-secondsale--aemsites.aem.page/group/ncsmig/)
